### PR TITLE
Add dark/light mode toggle to admin panel

### DIFF
--- a/src/app/admin/components/admin-layout/admin-layout.component.ts
+++ b/src/app/admin/components/admin-layout/admin-layout.component.ts
@@ -59,6 +59,10 @@ interface DatabaseHealth {
           <span class="toolbar-title">GGPoint Admin</span>
           <span class="spacer"></span>
 
+          <button mat-icon-button (click)="toggleTheme()" [attr.aria-label]="isDarkMode() ? 'Switch to light mode' : 'Switch to dark mode'">
+            <mat-icon>{{ isDarkMode() ? 'light_mode' : 'dark_mode' }}</mat-icon>
+          </button>
+
           <button mat-button [matMenuTriggerFor]="userMenu">
             <mat-icon>account_circle</mat-icon>
             {{ authService.currentUser()?.username }}
@@ -270,6 +274,7 @@ export class AdminLayoutComponent implements OnInit {
   private http = inject(HttpClient);
 
   dbHealth = signal<DatabaseHealth | null>(null);
+  isDarkMode = signal(false);
 
   sidenavOpened = true;
   sidenavMode: 'side' | 'over' = 'side';
@@ -285,6 +290,14 @@ export class AdminLayoutComponent implements OnInit {
     if (this.isBrowser && window.innerWidth < 768) {
       this.sidenavMode = 'over';
       this.sidenavOpened = false;
+    }
+
+    // Load theme preference
+    if (this.isBrowser) {
+      const savedTheme = localStorage.getItem('admin-theme');
+      const darkMode = savedTheme === 'dark';
+      this.isDarkMode.set(darkMode);
+      this.applyTheme(darkMode);
     }
   }
 
@@ -319,5 +332,26 @@ export class AdminLayoutComponent implements OnInit {
     this.authService.logout().subscribe(() => {
       this.router.navigate(['/login']);
     });
+  }
+
+  toggleTheme(): void {
+    const newDarkMode = !this.isDarkMode();
+    this.isDarkMode.set(newDarkMode);
+    this.applyTheme(newDarkMode);
+
+    if (this.isBrowser) {
+      localStorage.setItem('admin-theme', newDarkMode ? 'dark' : 'light');
+    }
+  }
+
+  private applyTheme(darkMode: boolean): void {
+    if (this.isBrowser) {
+      const htmlElement = document.documentElement;
+      if (darkMode) {
+        htmlElement.classList.add('dark-theme');
+      } else {
+        htmlElement.classList.remove('dark-theme');
+      }
+    }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -50,15 +50,18 @@ html {
 }
 
 // Dark mode scrollbar
-.dark ::-webkit-scrollbar-track {
+.dark ::-webkit-scrollbar-track,
+.dark-theme ::-webkit-scrollbar-track {
   background: #2d3748;
 }
 
-.dark ::-webkit-scrollbar-thumb {
+.dark ::-webkit-scrollbar-thumb,
+.dark-theme ::-webkit-scrollbar-thumb {
   background: #4a5568;
 }
 
-.dark ::-webkit-scrollbar-thumb:hover {
+.dark ::-webkit-scrollbar-thumb:hover,
+.dark-theme ::-webkit-scrollbar-thumb:hover {
   background: #718096;
 }
 
@@ -174,7 +177,8 @@ input.mat-mdc-input-element::placeholder {
 }
 
 // Dark mode overrides
-.dark {
+.dark,
+.dark-theme {
   .mat-mdc-form-field .mat-mdc-input-element,
   .mat-mdc-form-field input.mat-mdc-input-element,
   input.mat-mdc-input-element,

--- a/src/styles/material-theme.scss
+++ b/src/styles/material-theme.scss
@@ -32,7 +32,8 @@ html {
   @include mat.all-component-themes($ggpoint-theme);
 }
 
-// Apply dark theme when .dark class is present
-html.dark {
+// Apply dark theme when .dark or .dark-theme class is present
+html.dark,
+html.dark-theme {
   @include mat.all-component-themes($ggpoint-dark-theme);
 }


### PR DESCRIPTION
Features added:
- Add theme toggle button in admin toolbar (sun/moon icon)
- Implement theme switching logic with localStorage persistence
- Apply theme changes dynamically to html element with 'dark-theme' class
- Update Material theme to support both '.dark' and '.dark-theme' classes
- Update global styles to support both theme class names consistently
- Theme preference is saved and persists across browser sessions

This allows admin users to switch between light and dark modes:
- Light mode: White backgrounds with dark text (default)
- Dark mode: Dark blue/black backgrounds with white text
- Theme toggle button appears next to user menu in toolbar

https://claude.ai/code/session_014rVCmLMRgjawbhkyDLqxTm